### PR TITLE
Change optimization level to O2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CXXFLAGS+=-g
 endif
 ifndef DEBUG
 CFLAGS+=-O3
-CXXFLAGS+=-O3
+CXXFLAGS+=-O2
 endif
 
 VSQL?=vsql


### PR DESCRIPTION
I did get segmentation fault in function JsonQuery, after investigation I realized that this is the line causing the problem:
```
static void copyResult(const json_slice_t &json, Vertica::VString &result)
{
    result.copy(json.src, json.len);
}
```
I ended up with two solutions, one was to change optimziation level (for c++ only) to O2. The second was to copy json.src to temporary const char *, and then to result. I choose the first option because it won't double the number of allocations and didn't change the performance significantly (algorithm is written in C and still compiled with O3).