### PR TITLE
Handle null params in JsonQuery

### DIFF
--- a/src/JsonQuery.cpp
+++ b/src/JsonQuery.cpp
@@ -18,18 +18,21 @@ public:
 	                          Vertica::BlockWriter &resWriter)
 	{
 		do {
-			const Vertica::VString &jsonSrc = argReader.getStringRef(0);
-			const Vertica::VString &querySrc = argReader.getStringRef(1);
 			Vertica::VString &resSrc = resWriter.getStringRef();
-
-			json_slice_t jsonIn = json_slice_new(jsonSrc.data(), jsonSrc.length());
-			json_slice_t jsonOut;
-			if (json_slice_query(&jsonIn,
-			                     querySrc.data(), querySrc.length(),
-			                     &jsonOut)) {
-				Q::copyResult(jsonOut, resSrc);
-			} else {
+			if (argReader.isNull(0) || argReader.isNull(1)) {
 				resSrc.setNull();
+			} else {
+				const Vertica::VString &jsonSrc = argReader.getStringRef(0);
+				const Vertica::VString &querySrc = argReader.getStringRef(1);
+				json_slice_t jsonIn = json_slice_new(jsonSrc.data(), jsonSrc.length());
+				json_slice_t jsonOut;
+				if (json_slice_query(&jsonIn,
+						     querySrc.data(), querySrc.length(),
+						     &jsonOut)) {
+					Q::copyResult(jsonOut, resSrc);
+				} else {
+					resSrc.setNull();
+				}
 			}
 			resWriter.next();
 		} while (argReader.next());


### PR DESCRIPTION
While evaluating function on large datasets, with mixed null and not null params I was getting not null results from JsonQuery when the json param was null! 

Vertica C++ SDK have option to mark function as STRICT (or equivalently as RETURN_NULL_ON_NULL_INPUT), which was done in JsonQueryFactory, but despite of that function is still applied to null args. Vertica documentation confirm that the function shouldn't be called [Vertica Reference](https://my.vertica.com/docs/7.0.x/HTML/Content/Authoring/ProgrammersGuide/UserDefinedFunctions/SettingNullInputAndVolatilityBehavior.htm). I added explicit null check in function as a workaround.

Tested on server version v8.1.1-0.

